### PR TITLE
Fix import paths + Fix README for additional go binary requirement

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/jbeda/kuard",
+	"ImportPath": "github.com/kubernetes-up-and-running/kuard",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v75",
 	"Packages": [

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
 # Golang package.
-PKG := github.com/jbeda/kuard
+PKG := github.com/kubernetes-up-and-running/kuard
 
 # List of binaries to build. You must have a matching Dockerfile.BINARY
 # for each BINARY.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ If you want to do both Go server and React.js client dev, you need to do the fol
   * This will start a debug node server on `localhost:8081`.  It'll proxy all unhandled requests to `localhost:8080`
 
 3. In another terminal
+  * Ensure that $GOPATH is set to the directory with your go source code and binaries + ensure that $GOPATH is part of $PATH.
+  * `go get -u github.com/jteeuwen/go-bindata/...`
   * `go generate ./pkg/...`
   * `go run cmd/kuard/*.go --debug`
 4. Open your browser to http://localhost:8081.

--- a/cmd/kuard/main.go
+++ b/cmd/kuard/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/jbeda/kuard/pkg/app"
-	"github.com/jbeda/kuard/pkg/version"
+	"github.com/kubernetes-up-and-running/kuard/pkg/app"
+	"github.com/kubernetes-up-and-running/kuard/pkg/version"
 )
 
 func main() {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -25,14 +25,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jbeda/kuard/pkg/debugprobe"
-	"github.com/jbeda/kuard/pkg/dnsapi"
-	"github.com/jbeda/kuard/pkg/env"
-	"github.com/jbeda/kuard/pkg/htmlutils"
-	"github.com/jbeda/kuard/pkg/keygen"
-	"github.com/jbeda/kuard/pkg/memq/server"
-	"github.com/jbeda/kuard/pkg/sitedata"
-	"github.com/jbeda/kuard/pkg/version"
+	"github.com/kubernetes-up-and-running/kuard/pkg/debugprobe"
+	"github.com/kubernetes-up-and-running/kuard/pkg/dnsapi"
+	"github.com/kubernetes-up-and-running/kuard/pkg/env"
+	"github.com/kubernetes-up-and-running/kuard/pkg/htmlutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/keygen"
+	"github.com/kubernetes-up-and-running/kuard/pkg/memq/server"
+	"github.com/kubernetes-up-and-running/kuard/pkg/sitedata"
+	"github.com/kubernetes-up-and-running/kuard/pkg/version"
 
 	"github.com/julienschmidt/httprouter"
 )

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -16,9 +16,9 @@ limitations under the License.
 package app
 
 import (
-	"github.com/jbeda/kuard/pkg/debugprobe"
-	"github.com/jbeda/kuard/pkg/keygen"
-	"github.com/jbeda/kuard/pkg/sitedata"
+	"github.com/kubernetes-up-and-running/kuard/pkg/debugprobe"
+	"github.com/kubernetes-up-and-running/kuard/pkg/keygen"
+	"github.com/kubernetes-up-and-running/kuard/pkg/sitedata"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )

--- a/pkg/debugprobe/probe.go
+++ b/pkg/debugprobe/probe.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jbeda/kuard/pkg/apiutils"
-	"github.com/jbeda/kuard/pkg/htmlutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/apiutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/htmlutils"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/pkg/dnsapi/api.go
+++ b/pkg/dnsapi/api.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/jbeda/kuard/pkg/apiutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/apiutils"
 	"github.com/julienschmidt/httprouter"
 	"github.com/miekg/dns"
 )

--- a/pkg/env/api.go
+++ b/pkg/env/api.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jbeda/kuard/pkg/apiutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/apiutils"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/pkg/htmlutils/template.go
+++ b/pkg/htmlutils/template.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/jbeda/kuard/pkg/sitedata"
+	"github.com/kubernetes-up-and-running/kuard/pkg/sitedata"
 )
 
 type TemplateGroup struct {

--- a/pkg/keygen/api.go
+++ b/pkg/keygen/api.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/jbeda/kuard/pkg/apiutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/apiutils"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/pkg/keygen/memq.go
+++ b/pkg/keygen/memq.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/jbeda/kuard/pkg/memq/client"
+	"github.com/kubernetes-up-and-running/kuard/pkg/memq/client"
 )
 
 type memQWorker struct {

--- a/pkg/memq/client/client.go
+++ b/pkg/memq/client/client.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/jbeda/kuard/pkg/memq"
+	"github.com/kubernetes-up-and-running/kuard/pkg/memq"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/memq/server/api.go
+++ b/pkg/memq/server/api.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/jbeda/kuard/pkg/apiutils"
+	"github.com/kubernetes-up-and-running/kuard/pkg/apiutils"
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/pkg/memq/server/broker.go
+++ b/pkg/memq/server/broker.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jbeda/kuard/pkg/memq"
+	"github.com/kubernetes-up-and-running/kuard/pkg/memq"
 )
 
 var ErrEmptyQueue = errors.New("empty queue")


### PR DESCRIPTION
This fixes #2 

Change import paths across `go` files from `github.com/jbeda/kaurd` to `github.com/kubernetes-up-and-running/kuard`

Also, during development environment setup, it was found that this repo depends upon the `go` command line tool `go-bindata` being present. So, instructions have been added to `README.md` on how to install this tool.

The go server was started successfully on `localhost:8081` as part of the verification of this code change.