### PR TITLE
fix #21

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -114,6 +114,7 @@ define GO_BINARIES_RULE
 .PHONY: $(GO_BINARIES)
 $(GO_BINARIES): build/build.sh $(BUILD_IMAGE_BUILDSTAMP)
 	@echo "building : $$@"
+	@mkdir -p $(shell pwd)/bin/$(FAKEVER)/$(ARCH)
 	docker run                                                               \
 	    $(DOCKER_RUN_FLAGS)                                                  \
 	    --sig-proxy=true                                                     \


### PR DESCRIPTION
When docker maps a non-existent local directory, it creates the
directory as root. This causes error in the build because the
mapped directory is not writable by the current user.

Fixed by explicitly creating the directory before invoking docker.