### PR TITLE
Force line endings on *.sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf


### PR DESCRIPTION
Fix line endings for windows users. Do not allow user core.autocrlf to
change the line endings for *.sh files. This will fix issues building
container by removing the line endings on the shebang of the copied bash
files.

Users may need to delete all *.sh files, and then use `git restore` to update checked out files (another option for those that don't have changes is to delete and then clone the repo).