### PR TITLE
Update the Dockerfile for Windows runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV PKG=github.com/kubernetes-up-and-running/kuard
 ENV ARCH=amd64
 ENV VERSION=test
 
+# When running on Windows 10, you need to clean up the ^Ms in the script
+RUN dos2unix build/build.sh
+
 # Do the build. Script is part of incoming sources.
 RUN build/build.sh
 


### PR DESCRIPTION
If you will have the Windows line endings in the alpine image (from the COPY . .) it won't actually run the build script.