### PR TITLE
Switch to numeric USER lines to be supported by 'runAsNonRoot:true' (fixes issue #43)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN build/build.sh
 # STAGE 2: Runtime
 FROM alpine
 
-USER nobody:nobody
+# Set non-root nobody:nobody user (using UID:GID to support k8s SecurityContext runAsNonRoot:true)
+USER 65534:65534
+
 COPY --from=build /go/bin/kuard /kuard
 
 CMD [ "/kuard" ]

--- a/Dockerfile.kuard
+++ b/Dockerfile.kuard
@@ -16,5 +16,7 @@ FROM ARG_FROM
 
 ADD bin/ARG_FAKEVER/ARG_ARCH/kuard /kuard
 
-USER nobody:nobody
+# Set non-root nobody:nobody user (using UID:GID to support k8s SecurityContext runAsNonRoot:true)
+USER 65534:65534
+
 CMD ["/kuard"]

--- a/Dockerfile.nomultistage
+++ b/Dockerfile.nomultistage
@@ -21,7 +21,7 @@ ENV VERSION=test
 # Do the build. Script is part of incoming sources.
 RUN build/build.sh
 
-# At runtime run as non-root user
-USER nobody:nobody
+# Set non-root nobody:nobody user (using UID:GID to support k8s SecurityContext runAsNonRoot:true)
+USER 65534:65534
 
 CMD [ "/go/bin/kuard" ]


### PR DESCRIPTION
Fixing #43 for k8s deployments where `runAsNotRoot:true` is required.
