### PR TITLE
Support IPv6 DNS

### DIFF
--- a/pkg/dnsapi/api.go
+++ b/pkg/dnsapi/api.go
@@ -19,6 +19,7 @@ package dnsapi
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -99,11 +100,17 @@ func dnsQuery(t string, name string) (string, error) {
 		names = append(names, name)
 	}
 
+	server := config.Servers[0]
+	serverIP := net.ParseIP(server)
+	if serverIP.To4() == nil {
+		server = "[" + server + "]"
+	}
+
 	var r *dns.Msg
 	for _, name := range names {
 		m.SetQuestion(dns.Fqdn(name), qtype)
 		m.RecursionDesired = true
-		r, _, err = c.Exchange(m, config.Servers[0]+":"+config.Port)
+		r, _, err = c.Exchange(m, server+":"+config.Port)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
When attempting to use kuard where `/etc/resolv.conf` contained an IPv6 for the nameserver, it would error when making the DNS query due to [net.Dial](https://pkg.go.dev/net#Dial) expecting the IP to be surround with square brackets. In order to detect if it's IPv6, it parses the IP string to a `net.IP` and relies on [To4()](https://pkg.go.dev/net#IP.To4) returning nil for determining it's not a v4 and so must be a v6.